### PR TITLE
refactor: Set desktop as the Vue entry point

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,7 +18,7 @@
     "js": {
       "config": "src/config.ts",
       "mobile": "src/plugin.ts",
-      "desktop": "src/plugin.ts"
+      "desktop": "src/desktop.ts"
     }
   },
   "dev": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "vue": "^3.5.21"
       },
       "devDependencies": {
+        "@vitejs/plugin-vue": "^5.0.0",
         "vite": "^6.0.0"
       }
     },
@@ -809,6 +810,20 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.21",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "vue": "^3.5.21"
   },
   "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
     "vite": "^6.0.0"
   }
 }

--- a/src/config/App.vue
+++ b/src/config/App.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <h1>Hello, Vue!</h1>
+    <p>This is a sample Vue component.</p>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'App',
+});
+</script>
+
+<style scoped>
+h1 {
+  color: #42b983;
+}
+</style>

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './config/App.vue';
+
+createApp(App).mount('#app');

--- a/vite.plugins.ts
+++ b/vite.plugins.ts
@@ -1,4 +1,5 @@
+import vue from '@vitejs/plugin-vue';
 import { Plugin } from 'vite';
 
-const plugins: Plugin[] = [];
+const plugins: Plugin[] = [vue()];
 export default plugins;


### PR DESCRIPTION
This change updates the project configuration based on user feedback.

- Creates a new `src/desktop.ts` file to serve as the entry point for the Vue application.
- Updates `config.json` to use `src/desktop.ts` for the `desktop` entry.
- Restores `src/config.ts` to its original state, separating the plugin configuration logic from the Vue application.